### PR TITLE
Adds default zero hash generation to merkle tree pallet

### DIFF
--- a/pallets/mt/src/lib.rs
+++ b/pallets/mt/src/lib.rs
@@ -329,6 +329,8 @@ impl<T: Config<I>, I: 'static> TreeInterface<T, I> for Pallet<T, I> {
 		NextTreeId::<T, I>::mutate(|id| *id += One::one());
 		// get unit of two
 		let two: T::LeafIndex = Self::two();
+		// get default edge nodes
+		let default_edge_nodes = Self::default_hashes();
 		// Setting up the tree
 		let tree_metadata = TreeMetadata::<T::AccountId, T::LeafIndex, T::Element> {
 			creator,
@@ -337,7 +339,7 @@ impl<T: Config<I>, I: 'static> TreeInterface<T, I> for Pallet<T, I> {
 			max_leaves: two.saturating_pow(depth.into()),
 			leaf_count: T::LeafIndex::zero(),
 			root: T::Element::default(),
-			edge_nodes: vec![],
+			edge_nodes: default_edge_nodes,
 		};
 
 		Trees::<T, I>::insert(tree_id, tree_metadata);

--- a/pallets/mt/src/mock.rs
+++ b/pallets/mt/src/mock.rs
@@ -106,6 +106,7 @@ parameter_types! {
 	pub const Two: u64 = 2;
 	pub const MaxTreeDepth: u8 = 255;
 	pub const RootHistorySize: u32 = 1096;
+	pub const DefaultZeroElement = [0u8; 32];
 }
 
 #[derive(Debug, Encode, Decode, Default, Copy, Clone, PartialEq, Eq)]
@@ -127,6 +128,7 @@ impl Config for Test {
 	type DataDepositBase = LeafDepositBase;
 	type DataDepositPerByte = LeafDepositPerByte;
 	type Element = Element;
+	type DefaultZeroElement = DefaultZeroElement;
 	type Event = Event;
 	type ForceOrigin = frame_system::EnsureRoot<u64>;
 	type Hasher = HasherPallet;


### PR DESCRIPTION
- Initializes the pallet with `MaxDepth` zero hashes.
- Also fixes tree creation edge node setup.