### PR TITLE
Anchor pallet

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4258,6 +4258,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "pallet-anchor"
+version = "3.0.0"
+dependencies = [
+ "ark-crypto-primitives",
+ "darkwebb-primitives",
+ "frame-support",
+ "frame-system",
+ "pallet-balances",
+ "pallet-hasher",
+ "pallet-mixer",
+ "pallet-mt",
+ "pallet-verifier",
+ "parity-scale-codec",
+ "serde",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "sp-std",
+]
+
+[[package]]
 name = "pallet-aura"
 version = "3.0.0"
 source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.7#9c572625f6557dfdb19f47474369a0327d51dfbc"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1477,6 +1477,7 @@ dependencies = [
  "ark-crypto-primitives",
  "ark-ec",
  "ark-ff",
+ "ark-groth16",
  "ark-relations",
  "ark-serialize",
  "ark-std",
@@ -4521,6 +4522,7 @@ dependencies = [
 name = "pallet-verifier"
 version = "3.0.0"
 dependencies = [
+ "ark-crypto-primitives",
  "darkwebb-primitives",
  "frame-support",
  "frame-system",

--- a/pallets/anchor/Cargo.toml
+++ b/pallets/anchor/Cargo.toml
@@ -1,0 +1,52 @@
+[package]
+authors = ["Webb Technologies Inc."]
+edition = "2018"
+homepage = "https://substrate.dev"
+license = "Unlicense"
+name = "pallet-anchor"
+version = "3.0.0"
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
+# alias "parity-scale-code" to "codec"
+[dependencies.codec]
+default-features = false
+features = ["derive"]
+package = "parity-scale-codec"
+version = "2.0.0"
+
+[dependencies]
+frame-support = { default-features = false, version = "3.0.0", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.7" }
+frame-system = { default-features = false, version = "3.0.0", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.7" }
+sp-runtime = { default-features = false, version = "3.0.0", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.7" }
+sp-std = { default-features = false, version = "3.0.0", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.7" }
+pallet-hasher = { path = "../hasher", default-features = false }
+pallet-mixer = { path = "../mixer", default-features = false }
+pallet-mt = { path = "../mt", default-features = false }
+pallet-verifier = { path = "../verifier", default-features = false }
+darkwebb-primitives = { path = "../../primitives", default-features = false }
+
+[dev-dependencies]
+serde = { version = "1.0.119" }
+sp-core = { default-features = false, version = "3.0.0", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.7" }
+sp-io = { default-features = false, version = "3.0.0", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.7" }
+sp-runtime = { default-features = false, version = "3.0.0", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.7" }
+pallet-balances = { default-features = false, version = "3.0.0", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.7" }
+ark-crypto-primitives = { version = "^0.3.0", features = ["r1cs"], default-features = false }
+
+[features]
+default = ["std"]
+std = [
+    "codec/std",
+    "frame-support/std",
+    "frame-system/std",
+    "sp-runtime/std",
+    "sp-std/std",
+    "pallet-hasher/std",
+    "pallet-mt/std",
+    "pallet-mixer/std",
+    "pallet-verifier/std",
+    "darkwebb-primitives/std",
+    "ark-crypto-primitives/std",
+]

--- a/pallets/anchor/src/lib.rs
+++ b/pallets/anchor/src/lib.rs
@@ -86,9 +86,6 @@ pub mod pallet {
 		/// ChainID for anchor edges
 		type ChainId: Encode + Decode + Parameter + AtLeast32Bit + Default + Copy;
 
-		/// EdgeIndex type
-		type EdgeIndex: Encode + Decode + Parameter + AtLeast32Bit + Default + Copy;
-
 		/// The mixer type
 		type Mixer: MixerInterface<Self, I> + MixerInspector<Self, I>;
 

--- a/pallets/anchor/src/lib.rs
+++ b/pallets/anchor/src/lib.rs
@@ -104,7 +104,7 @@ pub mod pallet {
 	/// The parameter maintainer who can change the parameters
 	pub(super) type Maintainer<T: Config<I>, I: 'static = ()> = StorageValue<_, T::AccountId, ValueQuery>;
 
-	/// The map of trees to their metadata
+	/// The map of trees to their anchor metadata
 	#[pallet::storage]
 	#[pallet::getter(fn anchors)]
 	pub type Anchors<T: Config<I>, I: 'static = ()> =
@@ -116,7 +116,7 @@ pub mod pallet {
 	pub type MaxEdges<T: Config<I>, I: 'static = ()> =
 		StorageMap<_, Blake2_128Concat, T::TreeId, u32, ValueQuery>;
 
-	/// The map of trees to their metadata
+	/// The map of trees and chain ids to their edge metadata
 	#[pallet::storage]
 	#[pallet::getter(fn edge_list)]
 	pub type EdgeList<T: Config<I>, I: 'static = ()> = StorageDoubleMap<
@@ -129,7 +129,7 @@ pub mod pallet {
 		ValueQuery
 	>;
 
-	/// The map of trees to their metadata
+	/// A helper map for denoting whether an anchor is bridged to given chain
 	#[pallet::storage]
 	#[pallet::getter(fn anchor_has_edge)]
 	pub type AnchorHasEdge<T: Config<I>, I: 'static = ()> = StorageMap<
@@ -140,6 +140,7 @@ pub mod pallet {
 		ValueQuery
 	>;
 
+	/// The map of (tree, chain id) pairs to their latest recorded merkle root
 	#[pallet::storage]
 	#[pallet::getter(fn neighbor_roots)]
 	pub type NeighborRoots<T: Config<I>, I: 'static = ()> = StorageDoubleMap<
@@ -151,7 +152,7 @@ pub mod pallet {
 		T::Element,
 	>;
 
-	/// The next tree identifier up for grabs
+	/// The next neighbor root index to store the merkle root update record
 	#[pallet::storage]
 	#[pallet::getter(fn next_neighbor_root_index)]
 	pub type NextNeighborRootIndex<T: Config<I>, I: 'static = ()> = StorageMap<

--- a/pallets/anchor/src/lib.rs
+++ b/pallets/anchor/src/lib.rs
@@ -197,10 +197,11 @@ pub mod pallet {
 		#[pallet::weight(0)]
 		pub fn create(
 			origin: OriginFor<T>,
-			max_edges: u32,			
+			max_edges: u32,	
+			depth: u8,		
 		) -> DispatchResultWithPostInfo {
 			ensure_root(origin)?;
-			let tree_id = T::Mixer::create(T::AccountId::default(), 32u8)?;
+			let tree_id = T::Mixer::create(T::AccountId::default(), depth)?;
 			MaxEdges::<T, I>::insert(tree_id, max_edges);
 
 			Self::deposit_event(Event::AnchorCreation(tree_id));
@@ -242,7 +243,7 @@ pub mod pallet {
 
 impl<T: Config<I>, I: 'static> AnchorInterface<T, I> for Pallet<T, I> {
 	fn create(creator: T::AccountId, depth: u8) -> Result<T::TreeId, DispatchError> {
-		T::Mixer::create(T::AccountId::default(), 32u8)
+		T::Mixer::create(T::AccountId::default(), depth)
 	}
 
 	fn deposit(depositor: T::AccountId, id: T::TreeId, leaf: T::Element) -> Result<(), DispatchError> {

--- a/pallets/anchor/src/types.rs
+++ b/pallets/anchor/src/types.rs
@@ -4,9 +4,7 @@ use codec::{Decode, Encode};
 use frame_support::dispatch;
 
 /// Tree trait definition to be used in other pallets
-pub trait MixerInterface<T: Config<I>, I: 'static = ()> {
-	// Creates a new mixer
-	fn create(creator: T::AccountId, depth: u8) -> Result<T::TreeId, dispatch::DispatchError>;
+pub trait AnchorInterface<T: Config<I>, I: 'static = ()> {
 	/// Deposit into the mixer
 	fn deposit(account: T::AccountId, id: T::TreeId, leaf: T::Element) -> Result<(), dispatch::DispatchError>;
 	/// Withdraw into the mixer
@@ -21,16 +19,15 @@ pub trait MixerInterface<T: Config<I>, I: 'static = ()> {
 }
 
 /// Tree trait for inspecting tree state
-pub trait MixerInspector<T: Config<I>, I: 'static = ()> {
+pub trait AnchorInspector<T: Config<I>, I: 'static = ()> {
 	/// Gets the merkle root for a tree or returns `TreeDoesntExist`
-	fn get_root(id: T::TreeId) -> Result<T::Element, dispatch::DispatchError>;
-	/// Checks if a merkle root is in a tree's cached history or returns
+	fn get_neighbor_roots(id: T::TreeId) -> Result<T::Element, dispatch::DispatchError>;	/// Checks if a merkle root is in a tree's cached history or returns
 	/// `TreeDoesntExist
-	fn is_known_root(id: T::TreeId, target: T::Element) -> Result<bool, dispatch::DispatchError>;
+	fn is_known_neighbor_root(id: T::TreeId, target: T::Element) -> Result<bool, dispatch::DispatchError>;
 }
 
 #[derive(Default, Clone, Encode, Decode)]
-pub struct MixerMetadata<AccountId, Balance> {
+pub struct AnchorMetadata<AccountId, Balance> {
 	/// Creator account
 	pub creator: AccountId,
 	/// Balance size of deposit

--- a/pallets/anchor/src/types.rs
+++ b/pallets/anchor/src/types.rs
@@ -3,17 +3,17 @@ use crate::*;
 use codec::{Decode, Encode};
 use frame_support::dispatch;
 
-/// Tree trait definition to be used in other pallets
+/// Anchor trait definition to be used in other pallets
 pub trait AnchorInterface<T: Config<I>, I: 'static = ()> {
-	// Creates a new mixer
+	// Creates a new anchor
 	fn create(creator: T::AccountId, depth: u8) -> Result<T::TreeId, dispatch::DispatchError>;
-	/// Deposit into the mixer
+	/// Deposit into the anchor
 	fn deposit(
 		account: T::AccountId,
 		id: T::TreeId,
 		leaf: T::Element
 	) -> Result<(), dispatch::DispatchError>;
-	/// Withdraw into the mixer
+	/// Withdraw from the anchor
 	fn withdraw(
 		id: T::TreeId,
 		proof_bytes: &[u8],
@@ -24,14 +24,14 @@ pub trait AnchorInterface<T: Config<I>, I: 'static = ()> {
 		fee: BalanceOf<T, I>,
 		refund: BalanceOf<T, I>,
 	) -> Result<(), dispatch::DispatchError>;
-	/// Add an edge to this anchor bridge
+	/// Add an edge to this anchor
 	fn add_edge(
 		id: T::TreeId,
 		src_chain_id: T::ChainId,
 		root: T::Element,
 		height: T::BlockNumber
 	) -> Result<(), dispatch::DispatchError>;
-	/// Update an edge for this anchor bridge
+	/// Update an edge for this anchor
 	fn update_edge(
 		id: T::TreeId,
 		src_chain_id: T::ChainId,
@@ -40,7 +40,7 @@ pub trait AnchorInterface<T: Config<I>, I: 'static = ()> {
 	) -> Result<(), dispatch::DispatchError>;
 }
 
-/// Tree trait for inspecting tree state
+/// Anchor trait for inspecting tree state
 pub trait AnchorInspector<T: Config<I>, I: 'static = ()> {
 	/// Gets the merkle root for a tree or returns `TreeDoesntExist`
 	fn get_neighbor_roots(id: T::TreeId) -> Result<Vec<T::Element>, dispatch::DispatchError>;	/// Checks if a merkle root is in a tree's cached history or returns

--- a/pallets/anchor/src/types.rs
+++ b/pallets/anchor/src/types.rs
@@ -43,10 +43,18 @@ pub trait AnchorInterface<T: Config<I>, I: 'static = ()> {
 /// Anchor trait for inspecting tree state
 pub trait AnchorInspector<T: Config<I>, I: 'static = ()> {
 	/// Gets the merkle root for a tree or returns `TreeDoesntExist`
-	fn get_neighbor_roots(id: T::TreeId) -> Result<Vec<T::Element>, dispatch::DispatchError>;	/// Checks if a merkle root is in a tree's cached history or returns
-	/// `TreeDoesntExist
-	fn is_known_neighbor_root(id: T::TreeId, src_chain_id: T::ChainId, target: T::Element) -> Result<bool, dispatch::DispatchError>;
-	fn ensure_known_neighbor_root(id: T::TreeId, src_chain_id: T::ChainId, target: T::Element) -> Result<(), dispatch::DispatchError> {
+	fn get_neighbor_roots(id: T::TreeId) -> Result<Vec<T::Element>, dispatch::DispatchError>;
+	/// Checks if a merkle root is in a tree's cached history or returns `TreeDoesntExist
+	fn is_known_neighbor_root(
+		id: T::TreeId,
+		src_chain_id: T::ChainId,
+		target: T::Element
+	) -> Result<bool, dispatch::DispatchError>;
+	fn ensure_known_neighbor_root(
+		id: T::TreeId,
+		src_chain_id: T::ChainId,
+		target: T::Element
+	) -> Result<(), dispatch::DispatchError> {
 		let is_known = Self::is_known_neighbor_root(id, src_chain_id, target)?;
 		ensure!(is_known, Error::<T, I>::InvalidNeighborWithdrawRoot);
 		Ok(())

--- a/pallets/anchor/src/types.rs
+++ b/pallets/anchor/src/types.rs
@@ -27,14 +27,14 @@ pub trait AnchorInterface<T: Config<I>, I: 'static = ()> {
 	/// Add an edge to this anchor bridge
 	fn add_edge(
 		id: T::TreeId,
-		src_chain_id: u32,
+		src_chain_id: T::ChainId,
 		root: T::Element,
 		height: T::BlockNumber
 	) -> Result<(), dispatch::DispatchError>;
 	/// Update an edge for this anchor bridge
 	fn update_edge(
 		id: T::TreeId,
-		src_chain_id: u32,
+		src_chain_id: T::ChainId,
 		root: T::Element,
 		height: T::BlockNumber
 	) -> Result<(), dispatch::DispatchError>;
@@ -45,8 +45,8 @@ pub trait AnchorInspector<T: Config<I>, I: 'static = ()> {
 	/// Gets the merkle root for a tree or returns `TreeDoesntExist`
 	fn get_neighbor_roots(id: T::TreeId) -> Result<Vec<T::Element>, dispatch::DispatchError>;	/// Checks if a merkle root is in a tree's cached history or returns
 	/// `TreeDoesntExist
-	fn is_known_neighbor_root(id: T::TreeId, src_chain_id: u32, target: T::Element) -> Result<bool, dispatch::DispatchError>;
-	fn ensure_known_neighbor_root(id: T::TreeId, src_chain_id: u32, target: T::Element) -> Result<(), dispatch::DispatchError> {
+	fn is_known_neighbor_root(id: T::TreeId, src_chain_id: T::ChainId, target: T::Element) -> Result<bool, dispatch::DispatchError>;
+	fn ensure_known_neighbor_root(id: T::TreeId, src_chain_id: T::ChainId, target: T::Element) -> Result<(), dispatch::DispatchError> {
 		let is_known = Self::is_known_neighbor_root(id, src_chain_id, target)?;
 		ensure!(is_known, Error::<T, I>::InvalidNeighborWithdrawRoot);
 		Ok(())

--- a/pallets/mixer/Cargo.toml
+++ b/pallets/mixer/Cargo.toml
@@ -24,7 +24,7 @@ sp-std = { default-features = false, version = "3.0.0", git = "https://github.co
 pallet-hasher = { path = "../hasher", default-features = false }
 pallet-mt = { path = "../mt", default-features = false }
 pallet-verifier = { path = "../verifier", default-features = false }
-darkwebb-primitives = { path = "../../primitives", default-features = false }
+darkwebb-primitives = { path = "../../primitives", features = ["verifying"], default-features = false }
 
 [dev-dependencies]
 serde = { version = "1.0.119" }

--- a/pallets/mixer/src/lib.rs
+++ b/pallets/mixer/src/lib.rs
@@ -99,13 +99,13 @@ pub mod pallet {
 	/// The parameter maintainer who can change the parameters
 	pub(super) type Maintainer<T: Config<I>, I: 'static = ()> = StorageValue<_, T::AccountId, ValueQuery>;
 
-	/// The map of trees to their metadata
+	/// The map of trees to their mixer metadata
 	#[pallet::storage]
 	#[pallet::getter(fn mixers)]
 	pub type Mixers<T: Config<I>, I: 'static = ()> =
 		StorageMap<_, Blake2_128Concat, T::TreeId, MixerMetadata<T::AccountId, BalanceOf<T, I>>, ValueQuery>;
 
-	/// The map of trees to their metadata
+	/// The map of trees to their spent nullifier hashes
 	#[pallet::storage]
 	#[pallet::getter(fn nullifier_hashes)]
 	pub type NullifierHashes<T: Config<I>, I: 'static = ()> = StorageDoubleMap<

--- a/pallets/mixer/src/lib.rs
+++ b/pallets/mixer/src/lib.rs
@@ -233,7 +233,7 @@ impl<T: Config<I>, I: 'static> MixerInterface<T, I> for Pallet<T, I> {
 		ensure!(T::Tree::is_known_root(id, roots[0])?, Error::<T, I>::InvalidWithdrawRoot);
 		// Check nullifier and add or return `InvalidNullifier`
 		ensure!(
-			<Self as MixerInspector<_,_>>::is_nullifier_used(id, nullifier_hash),
+			!<Self as MixerInspector<_,_>>::is_nullifier_used(id, nullifier_hash),
 			Error::<T, I>::InvalidNullifier
 		);
 		Self::add_nullifier_hash(id, nullifier_hash);

--- a/pallets/mixer/src/lib.rs
+++ b/pallets/mixer/src/lib.rs
@@ -105,6 +105,19 @@ pub mod pallet {
 	pub type Mixers<T: Config<I>, I: 'static = ()> =
 		StorageMap<_, Blake2_128Concat, T::TreeId, MixerMetadata<T::AccountId, BalanceOf<T, I>>, ValueQuery>;
 
+	/// The map of trees to their metadata
+	#[pallet::storage]
+	#[pallet::getter(fn nullifier_hashes)]
+	pub type NullifierHashes<T: Config<I>, I: 'static = ()> = StorageDoubleMap<
+		_,
+		Blake2_128Concat,
+		T::TreeId,
+		Blake2_128Concat,
+		T::Element,
+		bool,
+		ValueQuery
+	>;
+
 	#[pallet::event]
 	#[pallet::generate_deposit(pub(super) fn deposit_event)]
 	#[pallet::metadata(T::AccountId = "AccountId", T::TreeId = "TreeId")]
@@ -120,6 +133,11 @@ pub mod pallet {
 		InvalidPermissions,
 		/// Invalid withdraw proof
 		InvalidWithdrawProof,
+		/// Invalid nullifier that is already used
+		/// (this error is thrown when a nullifier is used twice)
+		InvalidNullifier,
+		/// Invalid root used in withdrawal
+		InvalidWithdrawRoot,
 	}
 
 	#[pallet::hooks]
@@ -204,15 +222,28 @@ impl<T: Config<I>, I: 'static> MixerInterface<T, I> for Pallet<T, I> {
 	fn withdraw(
 		id: T::TreeId,
 		proof_bytes: &[u8],
+		roots: Vec<T::Element>,
 		nullifier_hash: T::Element,
 		recipient: T::AccountId,
 		relayer: T::AccountId,
 		fee: BalanceOf<T, I>,
+		refund: BalanceOf<T, I>,
 	) -> Result<(), DispatchError> {
-		let root = T::Tree::get_root(id)?;
+		// Check if local root is known
+		ensure!(T::Tree::is_known_root(id, roots[0])?, Error::<T, I>::InvalidWithdrawRoot);
+		// Check nullifier and add or return `InvalidNullifier`
+		ensure!(
+			<Self as MixerInspector<_,_>>::is_nullifier_used(id, nullifier_hash),
+			Error::<T, I>::InvalidNullifier
+		);
+		Self::add_nullifier_hash(id, nullifier_hash);
+		// Format proof public inputs for verification 
+		// FIXME: This is for a specfic gadget so we ought to create a generic handler
+		// FIXME: Such as a unpack/pack public inputs trait
+		// FIXME: 	-> T::PublicInputTrait::validate(public_bytes: &[u8])
 		let mut bytes = vec![];
 		bytes.extend_from_slice(&nullifier_hash.encode());
-		bytes.extend_from_slice(&root.encode());
+		bytes.extend_from_slice(&roots[0].encode());
 		bytes.extend_from_slice(&recipient.encode());
 		bytes.extend_from_slice(&relayer.encode());
 		// TODO: Update gadget being used to include fee as well
@@ -221,6 +252,12 @@ impl<T: Config<I>, I: 'static> MixerInterface<T, I> for Pallet<T, I> {
 		// fee.encode());
 		let result = <T as pallet::Config<I>>::Verifier::verify(&bytes, proof_bytes)?;
 		ensure!(result, Error::<T, I>::InvalidWithdrawProof);
+		// TODO: Transfer assets to the recipient
+		Ok(())
+	}
+
+	fn add_nullifier_hash(id: T::TreeId, nullifier_hash: T::Element) -> Result<(), DispatchError> {
+		NullifierHashes::<T, I>::insert(id, nullifier_hash, true);
 		Ok(())
 	}
 }
@@ -232,5 +269,9 @@ impl<T: Config<I>, I: 'static> MixerInspector<T, I> for Pallet<T, I> {
 
 	fn is_known_root(tree_id: T::TreeId, target_root: T::Element) -> Result<bool, DispatchError> {
 		T::Tree::is_known_root(tree_id, target_root)
+	}
+
+	fn is_nullifier_used(tree_id: T::TreeId, nullifier_hash: T::Element) -> bool {
+		NullifierHashes::<T, I>::contains_key(tree_id, nullifier_hash)
 	}
 }

--- a/pallets/mixer/src/lib.rs
+++ b/pallets/mixer/src/lib.rs
@@ -200,7 +200,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 
 impl<T: Config<I>, I: 'static> MixerInterface<T, I> for Pallet<T, I> {
 	fn create(creator: T::AccountId, depth: u8) -> Result<T::TreeId, DispatchError> {
-		T::Tree::create(T::AccountId::default(), 32u8)
+		T::Tree::create(T::AccountId::default(), depth)
 	}
 
 	fn deposit(depositor: T::AccountId, id: T::TreeId, leaf: T::Element) -> Result<(), DispatchError> {

--- a/pallets/mixer/src/types.rs
+++ b/pallets/mixer/src/types.rs
@@ -3,13 +3,13 @@ use crate::*;
 use codec::{Decode, Encode};
 use frame_support::{dispatch, ensure};
 
-/// Tree trait definition to be used in other pallets
+/// Mixer trait definition to be used in other pallets
 pub trait MixerInterface<T: Config<I>, I: 'static = ()> {
 	// Creates a new mixer
 	fn create(creator: T::AccountId, depth: u8) -> Result<T::TreeId, dispatch::DispatchError>;
 	/// Deposit into the mixer
 	fn deposit(account: T::AccountId, id: T::TreeId, leaf: T::Element) -> Result<(), dispatch::DispatchError>;
-	/// Withdraw into the mixer
+	/// Withdraw from the mixer
 	fn withdraw(
 		id: T::TreeId,
 		proof_bytes: &[u8],
@@ -24,7 +24,7 @@ pub trait MixerInterface<T: Config<I>, I: 'static = ()> {
 	fn add_nullifier_hash(id: T::TreeId, nullifier_hash: T::Element) -> Result<(), dispatch::DispatchError>;
 }
 
-/// Tree trait for inspecting tree state
+/// Mixer trait for inspecting mixer state
 pub trait MixerInspector<T: Config<I>, I: 'static = ()> {
 	/// Gets the merkle root for a tree or returns `TreeDoesntExist`
 	fn get_root(id: T::TreeId) -> Result<T::Element, dispatch::DispatchError>;

--- a/pallets/mixer/src/types.rs
+++ b/pallets/mixer/src/types.rs
@@ -1,7 +1,7 @@
 //! All the traits exposed to be used in other custom pallets
 use crate::*;
 use codec::{Decode, Encode};
-use frame_support::dispatch;
+use frame_support::{dispatch, ensure};
 
 /// Tree trait definition to be used in other pallets
 pub trait MixerInterface<T: Config<I>, I: 'static = ()> {
@@ -13,11 +13,15 @@ pub trait MixerInterface<T: Config<I>, I: 'static = ()> {
 	fn withdraw(
 		id: T::TreeId,
 		proof_bytes: &[u8],
+		roots: Vec<T::Element>,
 		nullifier_hash: T::Element,
 		recipient: T::AccountId,
 		relayer: T::AccountId,
 		fee: BalanceOf<T, I>,
+		refund: BalanceOf<T, I>,
 	) -> Result<(), dispatch::DispatchError>;
+	// Stores nullifier hash from a spend tx
+	fn add_nullifier_hash(id: T::TreeId, nullifier_hash: T::Element) -> Result<(), dispatch::DispatchError>;
 }
 
 /// Tree trait for inspecting tree state
@@ -27,6 +31,17 @@ pub trait MixerInspector<T: Config<I>, I: 'static = ()> {
 	/// Checks if a merkle root is in a tree's cached history or returns
 	/// `TreeDoesntExist
 	fn is_known_root(id: T::TreeId, target: T::Element) -> Result<bool, dispatch::DispatchError>;
+	fn ensure_known_root(id: T::TreeId, target: T::Element) -> Result<(), dispatch::DispatchError> {
+		let is_known: bool = Self::is_known_root(id, target)?;
+		ensure!(is_known, Error::<T, I>::InvalidWithdrawRoot);
+		Ok(())
+	}
+	/// Check if a nullifier has been used in a tree or returns `InvalidNullifier`
+	fn is_nullifier_used(id: T::TreeId, nullifier: T::Element) -> bool;
+	fn ensure_nullifier_unused(id : T::TreeId, nullifier: T::Element) -> Result<(), dispatch::DispatchError> {
+		ensure!(Self::is_nullifier_used(id, nullifier), Error::<T, I>::InvalidNullifier);
+		Ok(())
+	}
 }
 
 #[derive(Default, Clone, Encode, Decode)]

--- a/pallets/mixer/src/types.rs
+++ b/pallets/mixer/src/types.rs
@@ -39,7 +39,7 @@ pub trait MixerInspector<T: Config<I>, I: 'static = ()> {
 	/// Check if a nullifier has been used in a tree or returns `InvalidNullifier`
 	fn is_nullifier_used(id: T::TreeId, nullifier: T::Element) -> bool;
 	fn ensure_nullifier_unused(id : T::TreeId, nullifier: T::Element) -> Result<(), dispatch::DispatchError> {
-		ensure!(Self::is_nullifier_used(id, nullifier), Error::<T, I>::InvalidNullifier);
+		ensure!(Self::is_nullifier_used(id, nullifier), Error::<T, I>::AlreadyRevealedNullifier);
 		Ok(())
 	}
 }

--- a/pallets/mt/src/mock.rs
+++ b/pallets/mt/src/mock.rs
@@ -106,7 +106,7 @@ parameter_types! {
 	pub const Two: u64 = 2;
 	pub const MaxTreeDepth: u8 = 255;
 	pub const RootHistorySize: u32 = 1096;
-	pub const DefaultZeroElement = [0u8; 32];
+	pub const DefaultZeroElement: Element = Element([0u8; 32]);
 }
 
 #[derive(Debug, Encode, Decode, Default, Copy, Clone, PartialEq, Eq)]

--- a/pallets/verifier/Cargo.toml
+++ b/pallets/verifier/Cargo.toml
@@ -31,6 +31,7 @@ sp-core = { default-features = false, version = "3.0.0", git = "https://github.c
 sp-io = { default-features = false, version = "3.0.0", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.7" }
 sp-runtime = { default-features = false, version = "3.0.0", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.7" }
 pallet-balances = { default-features = false, version = "3.0.0", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.7" }
+ark-crypto-primitives = { version = "^0.3.0", features = ["r1cs"], default-features = false }
 
 [features]
 default = ["std"]
@@ -41,4 +42,5 @@ std = [
     "sp-runtime/std",
     "sp-std/std",
     "darkwebb-primitives/std",
+    "ark-crypto-primitives/std",
 ]

--- a/pallets/verifier/src/mock.rs
+++ b/pallets/verifier/src/mock.rs
@@ -74,8 +74,8 @@ impl pallet_balances::Config for Test {
 
 pub struct TestVerifier;
 impl InstanceVerifier for TestVerifier {
-	fn verify(_data: &[u8], _params: &[u8]) -> bool {
-		true
+	fn verify(pub_inps: &[u8], data: &[u8], _params: &[u8]) -> Result<bool, ark_crypto_primitives::Error> {
+		Ok(true)
 	}
 }
 

--- a/pallets/verifier/src/tests.rs
+++ b/pallets/verifier/src/tests.rs
@@ -1,9 +1,13 @@
+use super::*;
 use crate::mock::*;
+use frame_support::{assert_err, assert_ok, instances::Instance1};
 
 #[test]
-fn verify_nothing_with_test_verifier() {
+fn should_fail_to_verify_without_parameters() {
 	new_test_ext().execute_with(|| {
-		// Read pallet storage and assert an expected result.
-		assert_eq!(<VerifierPallet as VerifierModule>::verify(&[1u8; 32]), true);
+		// Pass arbitrary 
+		assert_err!(
+			<VerifierPallet as VerifierModule>::verify(&[1u8; 32], &[1u8; 32]),
+			Error::<Test, _>::ParametersNotInitialized);
 	});
 }

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -20,13 +20,14 @@ ark-serialize = { version = "^0.3.0", default-features = false, features = [ "de
 ark-bls12-381 = { version = "^0.3.0", default-features = false, features = [ "curve" ], optional = true }
 ark-bls12-377 = { version = "^0.3.0", default-features = false, features = [ "curve", "r1cs" ], optional = true }
 ark-bn254 = { version = "^0.3.0", default-features = false, features = [ "curve" ], optional = true }
+ark-groth16 = { version = "^0.3.0", default-features = false }
 tracing = { version = "0.1", default-features = false, features = [ "attributes" ], optional = true }
 
 blake2 = { version = "0.9", default-features = false }
 digest = "0.9"
 
 ark-crypto-primitives = { version = "^0.3.0", features = ["r1cs"], default-features = false }
-arkworks-gadgets = { version = "^0.3", default-features = false, optional = true }
+arkworks-gadgets = { version = "^0.3", features = ["default_poseidon", "default_mimc", "r1cs"], default-features = false, optional = true }
 
 [dependencies.codec]
 default-features = false
@@ -35,7 +36,7 @@ package = "parity-scale-codec"
 version = "2.0.0"
 
 [features]
-default = ["std", "hashing"]
+default = ["std", "hashing", "verifying"]
 std = [
 	"codec/std",
 	"frame-support/std",

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -7,6 +7,9 @@ pub mod verifier;
 #[cfg(feature = "hashing")]
 pub mod hashing;
 
+#[cfg(feature = "verifying")]
+pub mod verifying;
+
 pub use hasher::*;
 pub use types::*;
 pub use verifier::*;

--- a/primitives/src/verifying/arkworks.rs
+++ b/primitives/src/verifying/arkworks.rs
@@ -2,30 +2,31 @@ use crate::*;
 use sp_std::vec::Vec;
 use sp_std::marker::PhantomData;
 use ark_ff::{PrimeField, BigInteger};
+use ark_ec::PairingEngine;
 use ark_crypto_primitives::{Error};
 use ark_groth16::{Proof, VerifyingKey};
-use arkworks_gadgets::{
-	utils::{to_field_elements},
-	common::mixer::{get_public_inputs},
-};
+use arkworks_gadgets::utils::{to_field_elements};
+use arkworks_gadgets::setup::common::verify_groth16;
+use arkworks_gadgets::setup::mixer::get_public_inputs;
+use ark_serialize::CanonicalDeserialize;
 
 pub struct ArkworksMixerVerifierGroth16<E: PairingEngine>(PhantomData<E>);
 
 impl<E: PairingEngine> InstanceVerifier for ArkworksMixerVerifierGroth16<E> {
 	fn verify(public_inp_bytes: &[u8], proof_bytes: &[u8], vk_bytes: &[u8]) -> Result<bool, Error> {
-		let public_input_field_elts = to_field_elements::<E::Fr>(public_inp_bytes);
+		let public_input_field_elts = to_field_elements::<E::Fr>(public_inp_bytes).unwrap();
 		let public_inputs = get_public_inputs::<E::Fr>(
 			public_input_field_elts[0], // nullifier_hash
 			public_input_field_elts[1], // root
 			public_input_field_elts[2], // recipient
 			public_input_field_elts[3], // relayer
 		);
-		let vk = VerifyingKey::<E>::deserialize(&vk_bytes.unwrap()[..])?;
+		let vk = VerifyingKey::<E>::deserialize(&vk_bytes[..])?;
 		let proof = Proof::<E>::deserialize(&proof_bytes[..])?;
 		let res = verify_groth16::<E>(&vk, &public_inputs, &proof);
 		Ok(res)
 	}
 }
 
-use ark_bls12_381::{Fr as Bls381};
-pub type ArkworksBls381Verifier = ArkworksMixerVerifierGroth16<Bls381>;
+use ark_bls12_381::{Bls12_381};
+pub type ArkworksBls381Verifier = ArkworksMixerVerifierGroth16<Bls12_381>;


### PR DESCRIPTION
This PR adds a lot of architectural functionality modelled after: https://github.com/webb-tools/darkwebb-solidity/tree/main/contracts/anchors/bridged.

Primarily it integrates the Anchor pallet. This pallets:
- Consumes a verifier and a mixer module
- Exposes a deposit & withdraw API modelled after our solidity implementation
- Exposes a graph-like API for adding edges to trees, denoted by a map from tree_id -> chain_id -> edge metadata

Tests will be added in future PRs. For now, this gets the tests compiling for the other modules and compiling for the repo at large.